### PR TITLE
Fix Screen Recording permission window reappearing after access is granted

### DIFF
--- a/ScrollSnap/App/AppDelegate.swift
+++ b/ScrollSnap/App/AppDelegate.swift
@@ -151,18 +151,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @MainActor
     private func handleScreenRecordingPermissionOnLaunch() {
-        if presentOverlayIfScreenRecordingIsAllowed() {
-            showWhatsNewWindowIfNeeded()
+        if !hasScreenRecordingPermission() {
+            _ = requestScreenRecordingPermission()
+        }
+
+        // Only a missing grant may raise the permission window. An overlay that cannot be presented
+        // for some other reason is not a permission problem and must not be reported as one.
+        guard hasScreenRecordingPermission() else {
+            showScreenRecordingPermissionWindow()
             return
         }
 
-        _ = requestScreenRecordingPermission()
-
-        if !presentOverlayIfScreenRecordingIsAllowed() {
-            showScreenRecordingPermissionWindow()
-        } else {
-            showWhatsNewWindowIfNeeded()
-        }
+        presentOverlayIfScreenRecordingIsAllowed()
+        showWhatsNewWindowIfNeeded()
     }
 
     @MainActor
@@ -190,6 +191,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             },
             checkAgain: { [weak self] in
                 self?.checkScreenRecordingPermissionAgain()
+            },
+            relaunch: { [weak self] in
+                self?.relaunchApp()
             },
             quit: {
                 NSApplication.shared.terminate(nil)
@@ -223,12 +227,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @MainActor
     private func checkScreenRecordingPermissionAgain() {
-        if presentOverlayIfScreenRecordingIsAllowed() {
-            showWhatsNewWindowIfNeeded()
-        } else {
+        guard hasScreenRecordingPermission() else {
+            // This process will keep reading the old answer even once the switch is on, which is
+            // what the window's "Quit & Reopen" button is for.
             _ = requestScreenRecordingPermission()
-            if presentOverlayIfScreenRecordingIsAllowed() {
-                showWhatsNewWindowIfNeeded()
+            return
+        }
+
+        presentOverlayIfScreenRecordingIsAllowed()
+        showWhatsNewWindowIfNeeded()
+    }
+
+    /// Relaunches ScrollSnap so a Screen Recording grant made while it was running takes effect.
+    @MainActor
+    private func relaunchApp() {
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.createsNewApplicationInstance = true
+
+        NSWorkspace.shared.openApplication(
+            at: URL(fileURLWithPath: Bundle.main.bundlePath),
+            configuration: configuration
+        ) { _, _ in
+            Task { @MainActor in
+                NSApp.terminate(nil)
             }
         }
     }

--- a/ScrollSnap/Localizable.xcstrings
+++ b/ScrollSnap/Localizable.xcstrings
@@ -3487,6 +3487,30 @@
           }
         }
       }
+    },
+    "Quit & Reopen" : {
+      "comment" : "Button that relaunches ScrollSnap so a new Screen Recording grant takes effect.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quit & Reopen"
+          }
+        }
+      }
+    },
+    "Already allowed it? macOS only applies the change to a newly launched app, so reopen ScrollSnap." : {
+      "comment" : "Hint in the Screen Recording permission window explaining why a relaunch is needed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Already allowed it? macOS only applies the change to a newly launched app, so reopen ScrollSnap."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/ScrollSnap/Utilities/LocalizationSupport.swift
+++ b/ScrollSnap/Utilities/LocalizationSupport.swift
@@ -189,6 +189,14 @@ enum AppText {
         text("Check Again")
     }
 
+    static var relaunchApp: String {
+        text("Quit & Reopen")
+    }
+
+    static var screenRecordingRelaunchHint: String {
+        text("Already allowed it? macOS only applies the change to a newly launched app, so reopen ScrollSnap.")
+    }
+
     static var quit: String {
         text("Quit")
     }

--- a/ScrollSnap/Views/ScreenRecordingPermissionView.swift
+++ b/ScrollSnap/Views/ScreenRecordingPermissionView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct ScreenRecordingPermissionView: View {
     let openSystemSettings: () -> Void
     let checkAgain: () -> Void
+    let relaunch: () -> Void
     let quit: () -> Void
 
     var body: some View {
@@ -25,6 +26,14 @@ struct ScreenRecordingPermissionView: View {
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
+
+                // macOS only hands a new Screen Recording grant to a freshly launched process, so
+                // checking again in this one can never succeed after the switch is flipped.
+                Text(AppText.screenRecordingRelaunchHint)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             HStack(spacing: 10) {
@@ -36,6 +45,10 @@ struct ScreenRecordingPermissionView: View {
 
                 Button(AppText.checkAgain) {
                     checkAgain()
+                }
+
+                Button(AppText.relaunchApp) {
+                    relaunch()
                 }
 
                 Button(AppText.openSystemSettings) {
@@ -54,6 +67,7 @@ struct ScreenRecordingPermissionView_Previews: PreviewProvider {
         ScreenRecordingPermissionView(
             openSystemSettings: {},
             checkAgain: {},
+            relaunch: {},
             quit: {}
         )
     }


### PR DESCRIPTION
macOS reports a Screen Recording grant only to a process launched after the grant was made, so `CGPreflightScreenCaptureAccess` keeps returning false for the running app. "Check Again" cannot succeed in the launch that asked for access, and the window keeps coming back with the setting already switched on.

Adds a "Quit & Reopen" button that relaunches the app, and says in the window why a relaunch is needed.

Also stops raising the permission window when `presentOverlay()` returns false for reasons that have nothing to do with permission.

To see the old behaviour: revoke Screen Recording for ScrollSnap, launch it, grant access in System Settings, come back and press Check Again. It loops.

Two new strings, English only.
