### PR TITLE
Stitch frames with CoreGraphics instead of NSImage.lockFocus

### DIFF
--- a/ScrollSnap/App/AppDelegate.swift
+++ b/ScrollSnap/App/AppDelegate.swift
@@ -334,37 +334,44 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     
     /// Cleans up ScrollSnap temporary files older than the specified retention period
     private func cleanupOldTemporaryFiles() {
-        let tempDirectory = FileManager.default.temporaryDirectory
-        let retentionDays = 7 // Files older than this will be deleted
-        
+        // Resolved on the main actor, then swept off it so launch is not blocked on disk I/O.
+        let filenamePrefixes = AppText.supportedScreenshotFilenamePrefixes
+
+        Task.detached(priority: .utility) {
+            Self.removeTemporaryFiles(withPrefixes: filenamePrefixes, olderThanDays: 7)
+        }
+    }
+
+    private nonisolated static func removeTemporaryFiles(withPrefixes prefixes: [String], olderThanDays retentionDays: Int) {
+        let fileManager = FileManager.default
+        let tempDirectory = fileManager.temporaryDirectory
+
         do {
-            let tempContents = try FileManager.default.contentsOfDirectory(
+            let tempContents = try fileManager.contentsOfDirectory(
                 at: tempDirectory,
                 includingPropertiesForKeys: [.creationDateKey, .isRegularFileKey],
                 options: .skipsHiddenFiles
             )
-            
+
             let cutoffDate = Calendar.current.date(byAdding: .day, value: -retentionDays, to: Date()) ?? Date()
-            
+
             for fileURL in tempContents {
                 // Only process files that match ScrollSnap's naming pattern
-                guard AppText.supportedScreenshotFilenamePrefixes.contains(where: {
-                    fileURL.lastPathComponent.hasPrefix("\($0) ")
-                }) &&
-                      fileURL.pathExtension == "png" else {
+                guard fileURL.pathExtension == "png",
+                      prefixes.contains(where: { fileURL.lastPathComponent.hasPrefix("\($0) ") }) else {
                     continue
                 }
-                
+
                 do {
                     let resourceValues = try fileURL.resourceValues(forKeys: [.creationDateKey, .isRegularFileKey])
-                    
+
                     // Ensure it's a regular file
                     guard resourceValues.isRegularFile == true else { continue }
-                    
+
                     // Check if file is older than cutoff date
                     if let creationDate = resourceValues.creationDate,
                        creationDate < cutoffDate {
-                        try FileManager.default.removeItem(at: fileURL)
+                        try fileManager.removeItem(at: fileURL)
                     }
                 } catch {
                     print("Failed to process temp file \(fileURL.lastPathComponent): \(error.localizedDescription)")

--- a/ScrollSnap/Managers/StitchingManager.swift
+++ b/ScrollSnap/Managers/StitchingManager.swift
@@ -181,14 +181,16 @@ struct VisionOffsetEstimator: VerticalOffsetEstimating {
     }
 }
 
-class StitchingManager {
+/// Confines all of its mutable state to `stitchingQueue`, a serial queue, which is what makes the
+/// unchecked `Sendable` conformance safe: no property is touched outside that queue.
+final class StitchingManager: @unchecked Sendable {
     // MARK: - Properties
     private var runningStitchedImage: NSImage?
     private var previousImage: NSImage? // The most recent screenshot to use for comparison.
     private var hasPendingReverseOffset = false
     private let stitchingQueue = DispatchQueue(label: "com.scrollsnap.stitching", qos: .userInitiated)
     private let offsetEstimator: any VerticalOffsetEstimating
-    private let movementDeadZone: CGFloat = 3
+    private let movementDeadZone = Constants.Stitching.movementDeadZone
 
     init(offsetEstimator: any VerticalOffsetEstimating = VisionOffsetEstimator()) {
         self.offsetEstimator = offsetEstimator
@@ -197,9 +199,13 @@ class StitchingManager {
     // MARK: - Public API
     
     func startStitching(with initialImage: NSImage) {
-        runningStitchedImage = initialImage
-        previousImage = initialImage // On start, the initial image is also the previous one.
-        hasPendingReverseOffset = false
+        // State is owned by the stitching queue, so seed it there instead of racing with `addImage`.
+        stitchingQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.runningStitchedImage = initialImage
+            self.previousImage = initialImage // On start, the initial image is also the previous one.
+            self.hasPendingReverseOffset = false
+        }
     }
     
     func addImage(_ image: NSImage) {
@@ -293,51 +299,91 @@ class StitchingManager {
         return estimate.translation.y / (scale > 0 ? scale : 1.0)
     }
     
+    /// Appends the newly revealed strip of `newImage` below `baseImage`, working in pixels so that
+    /// Retina captures keep their full resolution no matter which display the app draws on.
     private func composite(baseImage: NSImage, newImage: NSImage, offset: CGFloat) -> NSImage? {
-        let baseSize = baseImage.size
-        let newSize = newImage.size
-        let newContentHeight = min(offset, newSize.height)
-        guard newContentHeight > 0 else { return nil }
-        
-        // The total height is the base height plus the new, non-overlapping area (the scroll amount).
-        let totalHeight = baseSize.height + newContentHeight
-        let outputSize = NSSize(width: baseSize.width, height: totalHeight)
-        
-        let outputImage = NSImage(size: outputSize)
-        outputImage.lockFocus()
-        
-        // Using a standard bottom-up coordinate system for drawing.
-        
-        // 1. Draw the base image above the newly revealed content.
-        let baseRect = CGRect(x: 0, y: newContentHeight, width: baseSize.width, height: baseSize.height)
-        baseImage.draw(in: baseRect)
-        
-        // 2. Draw only the newly exposed bottom strip from the latest screenshot.
-        let newContentRect = CGRect(x: 0, y: 0, width: newSize.width, height: newContentHeight)
-        newImage.draw(in: newContentRect, from: newContentRect, operation: .copy, fraction: 1.0)
-        
-        outputImage.unlockFocus()
+        guard let baseCGImage = baseImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
+              let newCGImage = newImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
+              let scale = pixelScale(of: baseImage, cgImage: baseCGImage) else {
+            return nil
+        }
 
-        return outputImage
+        let newContentHeightInPoints = min(offset, newImage.size.height)
+        guard newContentHeightInPoints > 0 else { return nil }
+
+        let newContentHeight = Int((newContentHeightInPoints * scale).rounded())
+        guard newContentHeight > 0, newContentHeight <= newCGImage.height else { return nil }
+
+        let outputWidth = baseCGImage.width
+        let outputHeight = baseCGImage.height + newContentHeight
+
+        // The strip sits at the bottom of the newest frame, which is the end of a top-left based image.
+        guard let newContent = newCGImage.cropping(to: CGRect(
+            x: 0,
+            y: newCGImage.height - newContentHeight,
+            width: newCGImage.width,
+            height: newContentHeight
+        )), let context = makeContext(width: outputWidth, height: outputHeight) else {
+            return nil
+        }
+
+        // CGContext draws bottom-up: the accumulated image goes above the freshly revealed strip.
+        context.draw(baseCGImage, in: CGRect(x: 0, y: newContentHeight, width: outputWidth, height: baseCGImage.height))
+        context.draw(newContent, in: CGRect(x: 0, y: 0, width: outputWidth, height: newContentHeight))
+
+        guard let outputImage = context.makeImage() else { return nil }
+
+        return NSImage(cgImage: outputImage, size: pointSize(pixelWidth: outputWidth, pixelHeight: outputHeight, scale: scale))
     }
 
     private func cropBottomRegion(of image: NSImage, byAmount amount: CGFloat) -> NSImage? {
         let originalSize = image.size
         guard amount > 0, amount < originalSize.height else { return image }
 
-        let newHeight = originalSize.height - amount
-        let newSize = NSSize(width: originalSize.width, height: newHeight)
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil),
+              let scale = pixelScale(of: image, cgImage: cgImage) else {
+            return nil
+        }
 
-        let croppedImage = NSImage(size: newSize)
-        croppedImage.lockFocus()
+        let croppedHeight = cgImage.height - Int((amount * scale).rounded())
+        guard croppedHeight > 0 else { return nil }
 
         // Keep the top content, crop from the bottom.
-        let sourceRect = NSRect(x: 0, y: amount, width: originalSize.width, height: newHeight)
-        let destRect = NSRect(origin: .zero, size: newSize)
+        guard let croppedImage = cgImage.cropping(to: CGRect(
+            x: 0,
+            y: 0,
+            width: cgImage.width,
+            height: croppedHeight
+        )) else {
+            return nil
+        }
 
-        image.draw(in: destRect, from: sourceRect, operation: .copy, fraction: 1.0)
+        return NSImage(
+            cgImage: croppedImage,
+            size: pointSize(pixelWidth: cgImage.width, pixelHeight: croppedHeight, scale: scale)
+        )
+    }
 
-        croppedImage.unlockFocus()
-        return croppedImage
+    private func makeContext(width: Int, height: Int) -> CGContext? {
+        CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        )
+    }
+
+    /// Pixels per point for an image, or `nil` when the image has no usable height.
+    private func pixelScale(of image: NSImage, cgImage: CGImage) -> CGFloat? {
+        guard image.size.height > 0 else { return nil }
+        let scale = CGFloat(cgImage.height) / image.size.height
+        return scale > 0 ? scale : nil
+    }
+
+    private func pointSize(pixelWidth: Int, pixelHeight: Int, scale: CGFloat) -> NSSize {
+        NSSize(width: CGFloat(pixelWidth) / scale, height: CGFloat(pixelHeight) / scale)
     }
 }

--- a/ScrollSnap/Utilities/Constants.swift
+++ b/ScrollSnap/Utilities/Constants.swift
@@ -46,6 +46,11 @@ struct Constants {
         static let collectionBehavior: NSWindow.CollectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     }
     
+    struct Stitching {
+        /// Vertical movement below this many points is treated as "the content did not move".
+        static let movementDeadZone: CGFloat = 3.0
+    }
+    
     struct Thumbnail {
         static let clickDistanceThreshold: CGFloat = 5    // Max movement for a click
         static let swipeDistanceThreshold: CGFloat = 20   // Min distance for swipe-right save

--- a/ScrollSnap/Utilities/ScreenshotUtilities.swift
+++ b/ScrollSnap/Utilities/ScreenshotUtilities.swift
@@ -278,6 +278,9 @@ private func promptForFolderAccess(for destination: SaveDestination, bookmarkKey
         let bookmarkData = try selectedURL.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
         UserDefaults.standard.set(bookmarkData, forKey: bookmarkKey)
         print("\(destination.rawValue) permission cached.")
+        // Balance the caller's `stopAccessingSecurityScopedResource()`, which runs for both the
+        // freshly picked and the restored-from-bookmark folder.
+        _ = selectedURL.startAccessingSecurityScopedResource()
         return selectedURL
     } catch {
         print("Failed to create bookmark for \(destination.rawValue): \(error)")


### PR DESCRIPTION
Five fixes in the stitching path, no intended change in behaviour. Existing tests pass unchanged.

- `composite()` and `cropBottomRegion()` drew with `NSImage.lockFocus()` on the private stitching queue. AppKit drawing off the main thread is unsupported, and `lockFocus` renders at the backing scale of whichever screen is current rather than the scale of the capture, so on a mixed-DPI setup every frame was resampled. Both now draw into a `CGContext` sized in pixels.
- `startStitching()` wrote `runningStitchedImage`, `previousImage` and `hasPendingReverseOffset` from the caller's thread while `addImage` read them on the stitching queue. Seeded on the queue that owns them now.
- Class marked `final` and `@unchecked Sendable`, which is accurate once all mutable state is queue-confined, and clears the concurrency warning on the `stopStitching` continuation.
- `saveImage` always calls `stopAccessingSecurityScopedResource()`, but a folder picked through `NSOpenPanel` never had `startAccessingSecurityScopedResource()` called on it. Only the bookmark path did.
- The launch-time temporary file sweep ran on the main actor and rebuilt the eight localized filename prefixes once per file. Moved off the main actor, prefixes resolved once.
