### PR TITLE
Stop repeating pinned UI down a scrolling capture

### DIFF
--- a/ScrollSnap/App/AppDelegate.swift
+++ b/ScrollSnap/App/AppDelegate.swift
@@ -334,37 +334,44 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     
     /// Cleans up ScrollSnap temporary files older than the specified retention period
     private func cleanupOldTemporaryFiles() {
-        let tempDirectory = FileManager.default.temporaryDirectory
-        let retentionDays = 7 // Files older than this will be deleted
-        
+        // Resolved on the main actor, then swept off it so launch is not blocked on disk I/O.
+        let filenamePrefixes = AppText.supportedScreenshotFilenamePrefixes
+
+        Task.detached(priority: .utility) {
+            Self.removeTemporaryFiles(withPrefixes: filenamePrefixes, olderThanDays: 7)
+        }
+    }
+
+    private nonisolated static func removeTemporaryFiles(withPrefixes prefixes: [String], olderThanDays retentionDays: Int) {
+        let fileManager = FileManager.default
+        let tempDirectory = fileManager.temporaryDirectory
+
         do {
-            let tempContents = try FileManager.default.contentsOfDirectory(
+            let tempContents = try fileManager.contentsOfDirectory(
                 at: tempDirectory,
                 includingPropertiesForKeys: [.creationDateKey, .isRegularFileKey],
                 options: .skipsHiddenFiles
             )
-            
+
             let cutoffDate = Calendar.current.date(byAdding: .day, value: -retentionDays, to: Date()) ?? Date()
-            
+
             for fileURL in tempContents {
                 // Only process files that match ScrollSnap's naming pattern
-                guard AppText.supportedScreenshotFilenamePrefixes.contains(where: {
-                    fileURL.lastPathComponent.hasPrefix("\($0) ")
-                }) &&
-                      fileURL.pathExtension == "png" else {
+                guard fileURL.pathExtension == "png",
+                      prefixes.contains(where: { fileURL.lastPathComponent.hasPrefix("\($0) ") }) else {
                     continue
                 }
-                
+
                 do {
                     let resourceValues = try fileURL.resourceValues(forKeys: [.creationDateKey, .isRegularFileKey])
-                    
+
                     // Ensure it's a regular file
                     guard resourceValues.isRegularFile == true else { continue }
-                    
+
                     // Check if file is older than cutoff date
                     if let creationDate = resourceValues.creationDate,
                        creationDate < cutoffDate {
-                        try FileManager.default.removeItem(at: fileURL)
+                        try fileManager.removeItem(at: fileURL)
                     }
                 } catch {
                     print("Failed to process temp file \(fileURL.lastPathComponent): \(error.localizedDescription)")

--- a/ScrollSnap/Managers/StitchingManager.swift
+++ b/ScrollSnap/Managers/StitchingManager.swift
@@ -181,14 +181,16 @@ struct VisionOffsetEstimator: VerticalOffsetEstimating {
     }
 }
 
-class StitchingManager {
+/// Confines all of its mutable state to `stitchingQueue`, a serial queue, which is what makes the
+/// unchecked `Sendable` conformance safe: no property is touched outside that queue.
+final class StitchingManager: @unchecked Sendable {
     // MARK: - Properties
     private var runningStitchedImage: NSImage?
     private var previousImage: NSImage? // The most recent screenshot to use for comparison.
     private var hasPendingReverseOffset = false
     private let stitchingQueue = DispatchQueue(label: "com.scrollsnap.stitching", qos: .userInitiated)
     private let offsetEstimator: any VerticalOffsetEstimating
-    private let movementDeadZone: CGFloat = 3
+    private let movementDeadZone = Constants.Stitching.movementDeadZone
 
     init(offsetEstimator: any VerticalOffsetEstimating = VisionOffsetEstimator()) {
         self.offsetEstimator = offsetEstimator
@@ -197,9 +199,13 @@ class StitchingManager {
     // MARK: - Public API
     
     func startStitching(with initialImage: NSImage) {
-        runningStitchedImage = initialImage
-        previousImage = initialImage // On start, the initial image is also the previous one.
-        hasPendingReverseOffset = false
+        // State is owned by the stitching queue, so seed it there instead of racing with `addImage`.
+        stitchingQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.runningStitchedImage = initialImage
+            self.previousImage = initialImage // On start, the initial image is also the previous one.
+            self.hasPendingReverseOffset = false
+        }
     }
     
     func addImage(_ image: NSImage) {
@@ -293,51 +299,91 @@ class StitchingManager {
         return estimate.translation.y / (scale > 0 ? scale : 1.0)
     }
     
+    /// Appends the newly revealed strip of `newImage` below `baseImage`, working in pixels so that
+    /// Retina captures keep their full resolution no matter which display the app draws on.
     private func composite(baseImage: NSImage, newImage: NSImage, offset: CGFloat) -> NSImage? {
-        let baseSize = baseImage.size
-        let newSize = newImage.size
-        let newContentHeight = min(offset, newSize.height)
-        guard newContentHeight > 0 else { return nil }
-        
-        // The total height is the base height plus the new, non-overlapping area (the scroll amount).
-        let totalHeight = baseSize.height + newContentHeight
-        let outputSize = NSSize(width: baseSize.width, height: totalHeight)
-        
-        let outputImage = NSImage(size: outputSize)
-        outputImage.lockFocus()
-        
-        // Using a standard bottom-up coordinate system for drawing.
-        
-        // 1. Draw the base image above the newly revealed content.
-        let baseRect = CGRect(x: 0, y: newContentHeight, width: baseSize.width, height: baseSize.height)
-        baseImage.draw(in: baseRect)
-        
-        // 2. Draw only the newly exposed bottom strip from the latest screenshot.
-        let newContentRect = CGRect(x: 0, y: 0, width: newSize.width, height: newContentHeight)
-        newImage.draw(in: newContentRect, from: newContentRect, operation: .copy, fraction: 1.0)
-        
-        outputImage.unlockFocus()
+        guard let baseCGImage = baseImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
+              let newCGImage = newImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
+              let scale = pixelScale(of: baseImage, cgImage: baseCGImage) else {
+            return nil
+        }
 
-        return outputImage
+        let newContentHeightInPoints = min(offset, newImage.size.height)
+        guard newContentHeightInPoints > 0 else { return nil }
+
+        let newContentHeight = Int((newContentHeightInPoints * scale).rounded())
+        guard newContentHeight > 0, newContentHeight <= newCGImage.height else { return nil }
+
+        let outputWidth = baseCGImage.width
+        let outputHeight = baseCGImage.height + newContentHeight
+
+        // The strip sits at the bottom of the newest frame, which is the end of a top-left based image.
+        guard let newContent = newCGImage.cropping(to: CGRect(
+            x: 0,
+            y: newCGImage.height - newContentHeight,
+            width: newCGImage.width,
+            height: newContentHeight
+        )), let context = makeContext(width: outputWidth, height: outputHeight) else {
+            return nil
+        }
+
+        // CGContext draws bottom-up: the accumulated image goes above the freshly revealed strip.
+        context.draw(baseCGImage, in: CGRect(x: 0, y: newContentHeight, width: outputWidth, height: baseCGImage.height))
+        context.draw(newContent, in: CGRect(x: 0, y: 0, width: outputWidth, height: newContentHeight))
+
+        guard let outputImage = context.makeImage() else { return nil }
+
+        return NSImage(cgImage: outputImage, size: pointSize(pixelWidth: outputWidth, pixelHeight: outputHeight, scale: scale))
     }
 
     private func cropBottomRegion(of image: NSImage, byAmount amount: CGFloat) -> NSImage? {
         let originalSize = image.size
         guard amount > 0, amount < originalSize.height else { return image }
 
-        let newHeight = originalSize.height - amount
-        let newSize = NSSize(width: originalSize.width, height: newHeight)
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil),
+              let scale = pixelScale(of: image, cgImage: cgImage) else {
+            return nil
+        }
 
-        let croppedImage = NSImage(size: newSize)
-        croppedImage.lockFocus()
+        let croppedHeight = cgImage.height - Int((amount * scale).rounded())
+        guard croppedHeight > 0 else { return nil }
 
         // Keep the top content, crop from the bottom.
-        let sourceRect = NSRect(x: 0, y: amount, width: originalSize.width, height: newHeight)
-        let destRect = NSRect(origin: .zero, size: newSize)
+        guard let croppedImage = cgImage.cropping(to: CGRect(
+            x: 0,
+            y: 0,
+            width: cgImage.width,
+            height: croppedHeight
+        )) else {
+            return nil
+        }
 
-        image.draw(in: destRect, from: sourceRect, operation: .copy, fraction: 1.0)
+        return NSImage(
+            cgImage: croppedImage,
+            size: pointSize(pixelWidth: cgImage.width, pixelHeight: croppedHeight, scale: scale)
+        )
+    }
 
-        croppedImage.unlockFocus()
-        return croppedImage
+    private func makeContext(width: Int, height: Int) -> CGContext? {
+        CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        )
+    }
+
+    /// Pixels per point for an image, or `nil` when the image has no usable height.
+    private func pixelScale(of image: NSImage, cgImage: CGImage) -> CGFloat? {
+        guard image.size.height > 0 else { return nil }
+        let scale = CGFloat(cgImage.height) / image.size.height
+        return scale > 0 ? scale : nil
+    }
+
+    private func pointSize(pixelWidth: Int, pixelHeight: Int, scale: CGFloat) -> NSSize {
+        NSSize(width: CGFloat(pixelWidth) / scale, height: CGFloat(pixelHeight) / scale)
     }
 }

--- a/ScrollSnap/Managers/StitchingManager.swift
+++ b/ScrollSnap/Managers/StitchingManager.swift
@@ -301,6 +301,11 @@ final class StitchingManager: @unchecked Sendable {
     
     /// Appends the newly revealed strip of `newImage` below `baseImage`, working in pixels so that
     /// Retina captures keep their full resolution no matter which display the app draws on.
+    ///
+    /// The sampled strip reaches past the new content into the tail of what is already stitched, so
+    /// that region is redrawn from this frame. Content pinned to the bottom edge of the captured
+    /// window is stamped into every frame at the same place; by the next frame the real content
+    /// underneath it has scrolled clear of the edge, and redrawing replaces the copy with it.
     private func composite(baseImage: NSImage, newImage: NSImage, offset: CGFloat) -> NSImage? {
         guard let baseCGImage = baseImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
               let newCGImage = newImage.cgImage(forProposedRect: nil, context: nil, hints: nil),
@@ -317,19 +322,29 @@ final class StitchingManager: @unchecked Sendable {
         let outputWidth = baseCGImage.width
         let outputHeight = baseCGImage.height + newContentHeight
 
+        // Reach past the new content into the stitched tail, as far as this frame can supply and the
+        // accumulated image can spare.
+        let repairHeight = max(0, min(
+            Int((Constants.Stitching.trailingRepairHeight * scale).rounded()),
+            newCGImage.height - newContentHeight,
+            baseCGImage.height
+        ))
+        let sampledHeight = newContentHeight + repairHeight
+
         // The strip sits at the bottom of the newest frame, which is the end of a top-left based image.
         guard let newContent = newCGImage.cropping(to: CGRect(
             x: 0,
-            y: newCGImage.height - newContentHeight,
+            y: newCGImage.height - sampledHeight,
             width: newCGImage.width,
-            height: newContentHeight
+            height: sampledHeight
         )), let context = makeContext(width: outputWidth, height: outputHeight) else {
             return nil
         }
 
-        // CGContext draws bottom-up: the accumulated image goes above the freshly revealed strip.
+        // CGContext draws bottom-up: the accumulated image goes down first, then the sampled strip
+        // over it, which both appends the new content and repaints the tail underneath.
         context.draw(baseCGImage, in: CGRect(x: 0, y: newContentHeight, width: outputWidth, height: baseCGImage.height))
-        context.draw(newContent, in: CGRect(x: 0, y: 0, width: outputWidth, height: newContentHeight))
+        context.draw(newContent, in: CGRect(x: 0, y: 0, width: outputWidth, height: sampledHeight))
 
         guard let outputImage = context.makeImage() else { return nil }
 

--- a/ScrollSnap/Utilities/Constants.swift
+++ b/ScrollSnap/Utilities/Constants.swift
@@ -46,6 +46,11 @@ struct Constants {
         static let collectionBehavior: NSWindow.CollectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     }
     
+    struct Stitching {
+        /// Vertical movement below this many points is treated as "the content did not move".
+        static let movementDeadZone: CGFloat = 3.0
+    }
+    
     struct Thumbnail {
         static let clickDistanceThreshold: CGFloat = 5    // Max movement for a click
         static let swipeDistanceThreshold: CGFloat = 20   // Min distance for swipe-right save

--- a/ScrollSnap/Utilities/Constants.swift
+++ b/ScrollSnap/Utilities/Constants.swift
@@ -49,6 +49,12 @@ struct Constants {
     struct Stitching {
         /// Vertical movement below this many points is treated as "the content did not move".
         static let movementDeadZone: CGFloat = 3.0
+        /// How much of the already-stitched tail each new frame redraws. Anything pinned to the
+        /// bottom of the captured window — a floating button, a sticky footer, an edge gradient —
+        /// sits in the strip that would otherwise be appended verbatim, once per frame. Redrawing
+        /// the tail from the next frame, where that content has scrolled clear of the edge, removes
+        /// it instead of accumulating it.
+        static let trailingRepairHeight: CGFloat = 100.0
     }
     
     struct Thumbnail {

--- a/ScrollSnap/Utilities/ScreenshotUtilities.swift
+++ b/ScrollSnap/Utilities/ScreenshotUtilities.swift
@@ -278,6 +278,9 @@ private func promptForFolderAccess(for destination: SaveDestination, bookmarkKey
         let bookmarkData = try selectedURL.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
         UserDefaults.standard.set(bookmarkData, forKey: bookmarkKey)
         print("\(destination.rawValue) permission cached.")
+        // Balance the caller's `stopAccessingSecurityScopedResource()`, which runs for both the
+        // freshly picked and the restored-from-bookmark folder.
+        _ = selectedURL.startAccessingSecurityScopedResource()
         return selectedURL
     } catch {
         print("Failed to create bookmark for \(destination.rawValue): \(error)")

--- a/ScrollSnapTests/StitchingManagerTests.swift
+++ b/ScrollSnapTests/StitchingManagerTests.swift
@@ -175,6 +175,52 @@ final class StitchingManagerTests: XCTestCase {
         XCTAssertNil(beyondBoundary)
     }
 
+    /// Anything pinned to the bottom edge of the captured window lands in every frame's strip. The
+    /// next frame has to repaint it away rather than leave one copy per band.
+    func testTrailingTailIsRepaintedFromTheNewestFrame() async {
+        let manager = StitchingManager(offsetEstimator: SequenceOffsetEstimator([estimate(y: 20)]))
+        manager.startStitching(with: makeSolidImage(blue: true))
+        manager.addImage(makeSolidImage(blue: false))
+
+        guard let result = await manager.stopStitching() else {
+            return XCTFail("Expected a stitched image")
+        }
+
+        XCTAssertEqual(result.size.height, 120)
+        // 50 pt up from the bottom sits in territory the base image had already claimed. It must now
+        // carry the newest frame's pixels, not the ones stitched a frame ago.
+        XCTAssertTrue(isGreen(at: 50, in: result))
+        XCTAssertFalse(isGreen(at: 115, in: result), "Content above the repaired tail must stand")
+    }
+
+    private func isGreen(at y: CGFloat, in image: NSImage) -> Bool {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return false
+        }
+
+        let bitmap = NSBitmapImageRep(cgImage: cgImage)
+        let row = min(max(Int(image.size.height - y), 0), bitmap.pixelsHigh - 1)
+        guard let color = bitmap.colorAt(x: bitmap.pixelsWide / 2, y: row) else { return false }
+        return color.greenComponent > 0.5 && color.blueComponent < 0.5
+    }
+
+    private func makeSolidImage(blue: Bool) -> NSImage {
+        let width = 40, height = 100
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+
+        context.setFillColor(CGColor(red: 0, green: blue ? 0 : 1, blue: blue ? 1 : 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return NSImage(cgImage: context.makeImage()!, size: NSSize(width: width, height: height))
+    }
+
     private func estimate(y: CGFloat) -> OffsetEstimate {
         OffsetEstimate(
             translation: CGPoint(x: 0, y: y),


### PR DESCRIPTION
Based on #21, so the diff here includes that commit as well. Merge #21 first and this one shrinks to its own change.

`composite()` appends the bottom strip of each frame, which is right for content that scrolls but not for anything fixed to the viewport. A floating button, a sticky footer, or the gradient fade many scroll views draw at their bottom edge sits in that strip in every frame, so it gets appended once per frame. On a long capture it repeats every few dozen points down the image.

Each frame now samples past the new content into the tail of what is already stitched, up to `Constants.Stitching.trailingRepairHeight`, and redraws that region from the current frame. Content that sat under a fixed element has scrolled clear of the edge by the next frame, so redrawing replaces the copy with what was really there. Bounded by what the frame can supply and what the accumulated image can spare; with nothing pinned it redraws identical pixels.

The last band of a capture keeps its copy, since no later frame arrives to repair it.

New test asserts the repainted pixels rather than the output height.
