### PR TITLE
Let the overlay pass clicks through to everything it is not using

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ ScrollSnap is an open-source macOS application designed to capture scrolling scr
 
 - **Customizable Selection Area**: Resize and drag a selection rectangle to define the capture region.
 - **Scrolling Capture**: Automatically stitches multiple screenshots into a single image for capturing long content.
-- **Keyboard Shortcut**: Press `Return` while the overlay is active to start or stop scrolling capture.
+- **Stays Out of the Way**: The overlay only intercepts clicks on its own controls, so the Dock, the menu bar, and the app you are capturing all stay clickable while it is up.
+- **Keyboard Shortcut**: Press `Return` while the overlay is active to start or stop scrolling capture, or press the global shortcut, which toggles the capture from any app.
 - **Interactive Menu**: Includes options to capture, save, reset positions, or cancel, with a draggable interface.
 - **Thumbnail Preview**: Displays a draggable thumbnail of the captured image with swipe-to-save or right-click options.
 - **Save Destinations**: Supports saving to Desktop, Documents, Downloads, Clipboard, or opening in Preview.
@@ -59,6 +60,7 @@ Whether you want to add a completely new language or improve an existing transla
 2. **Show the Overlay**:
 
 - Press `Control + Option + S` from any app. You can change, disable, or reset this global shortcut in Settings (`Cmd + ,`).
+- The overlay floats above your windows without blocking them: click the Dock, the menu bar, or any visible window to bring the app you want to capture forward.
 
 3. **Adjust the Selection**:
 
@@ -112,7 +114,7 @@ ScrollSnap
 
 ## How It Works
 
-- **Overlay System**: `OverlayManager` creates overlays on all screens, managed by `OverlayView`, which delegates drawing and interaction to `SelectionRectangleView` and `MenuBarView`.
+- **Overlay System**: `OverlayManager` creates overlays on all screens, managed by `OverlayView`, which delegates drawing and interaction to `SelectionRectangleView` and `MenuBarView`. The overlay sits just below the Dock and passes the pointer through everywhere except its own controls.
 - **Screenshot Capture**: `ScreenshotUtilities` uses ScreenCaptureKit to capture the defined rectangle, excluding the app’s UI.
 - **Scrolling Capture**: `StitchingManager` combines screenshots into a single image using overlap detection.
 - **Thumbnail**: `ThumbnailView` provides an interactive preview with drag-and-drop and swipe gestures.

--- a/ScrollSnap/App/AppDelegate.swift
+++ b/ScrollSnap/App/AppDelegate.swift
@@ -113,8 +113,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func installGlobalShortcutHandler() {
         shortcutTask = Task { @MainActor [weak self] in
             for await _ in KeyboardShortcuts.events(.keyUp, for: .invokeScrollSnap) {
-                self?.presentCaptureInterface()
+                self?.handleGlobalShortcut()
             }
+        }
+    }
+
+    /// The global shortcut doubles as a capture toggle so the overlay can be driven while another
+    /// app keeps keyboard focus.
+    @MainActor
+    private func handleGlobalShortcut() {
+        guard screenRecordingPermissionWindow == nil,
+              whatsNewWindow == nil else {
+            return
+        }
+
+        switch overlayManager.sessionState {
+        case .selecting, .capturing:
+            overlayManager.captureScreenshot()
+        case .thumbnail:
+            overlayManager.hideThumbnail()
+            presentCaptureInterface()
+        case .idle:
+            presentCaptureInterface()
+        case .finishing:
+            break
         }
     }
 

--- a/ScrollSnap/Managers/OverlayManager.swift
+++ b/ScrollSnap/Managers/OverlayManager.swift
@@ -44,6 +44,10 @@ class OverlayManager {
     private var thumbnailSessionID: UUID?
     private var captureTimer: Timer?
     private var scrollingCaptureSession: ScrollingCaptureSession?
+    private var pointerMonitors: [Any] = []
+    private var pointerPollTimer: Timer?
+    private var isOverlayIgnoringMouseEvents = false
+    private var optionsPopupRect: NSRect?
     var thumbnailWindow: NSWindow?
     private var suspendedWindowsState: SuspendedWindowsState?
     private var activeSuspensionReasons = Set<FloatingWindowSuspensionReason>()
@@ -77,6 +81,8 @@ class OverlayManager {
         rebuildOverlayWindows()
         sessionState = .selecting
         syncOverlayWindows()
+        installPointerMonitors()
+        updatePointerTransparency()
         return true
     }
 
@@ -152,6 +158,8 @@ class OverlayManager {
     }
     
     func setOverlayIgnoresMouseEvents(_ ignoresMouseEvents: Bool) {
+        guard isOverlayIgnoringMouseEvents != ignoresMouseEvents else { return }
+        isOverlayIgnoringMouseEvents = ignoresMouseEvents
         overlayWindows.forEach { $0.ignoresMouseEvents = ignoresMouseEvents }
     }
 
@@ -436,7 +444,96 @@ class OverlayManager {
     
     // MARK: - Overlay Visibility
     private func hideOverlays() {
-        overlayWindows.forEach { $0.orderOut(nil) }
+        removePointerMonitors()
+        optionsPopupRect = nil
+        isOverlayIgnoringMouseEvents = false
+        overlayWindows.forEach {
+            $0.ignoresMouseEvents = false
+            $0.orderOut(nil)
+        }
+    }
+
+    // MARK: - Pointer Pass-Through
+
+    /// Tracks the pointer so the overlay only intercepts clicks that belong to its own chrome.
+    /// Everything else — the app being captured, the Dock, the menu bar — stays clickable.
+    private func installPointerMonitors() {
+        guard pointerMonitors.isEmpty else { return }
+
+        // Event monitors react instantly; the poll is a safety net for pointer movement they miss.
+        let pollTimer = Timer(timeInterval: Constants.Overlay.pointerPollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updatePointerTransparency()
+            }
+        }
+        RunLoop.main.add(pollTimer, forMode: .common)
+        pointerPollTimer = pollTimer
+
+        let mask: NSEvent.EventTypeMask = [.mouseMoved, .leftMouseUp, .rightMouseUp, .otherMouseUp]
+
+        if let globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: { [weak self] _ in
+            Task { @MainActor in
+                self?.updatePointerTransparency()
+            }
+        }) {
+            pointerMonitors.append(globalMonitor)
+        }
+
+        if let localMonitor = NSEvent.addLocalMonitorForEvents(matching: mask, handler: { [weak self] event in
+            self?.updatePointerTransparency()
+            return event
+        }) {
+            pointerMonitors.append(localMonitor)
+        }
+    }
+
+    private func removePointerMonitors() {
+        pointerPollTimer?.invalidate()
+        pointerPollTimer = nil
+        pointerMonitors.forEach { NSEvent.removeMonitor($0) }
+        pointerMonitors.removeAll()
+    }
+
+    /// Lets the overlay window swallow the pointer only while it is over overlay chrome.
+    private func updatePointerTransparency() {
+        guard !overlayWindows.isEmpty,
+              sessionState == .selecting || sessionState == .capturing else { return }
+
+        // Never flip mid-gesture: a drag that started on the overlay has to keep receiving events.
+        guard NSEvent.pressedMouseButtons == 0 else { return }
+
+        let isOverChrome = isPointOverOverlayChrome(NSEvent.mouseLocation)
+        setOverlayIgnoresMouseEvents(!isOverChrome)
+
+        if !isOverChrome {
+            clearMenuHoverStates()
+        }
+    }
+
+    private func isPointOverOverlayChrome(_ point: NSPoint) -> Bool {
+        if let optionsPopupRect, optionsPopupRect.contains(point) {
+            return true
+        }
+
+        if menuRect.contains(point) {
+            return true
+        }
+
+        // While capturing, the selection has to pass scroll events through to the captured app.
+        guard sessionState == .selecting else { return false }
+
+        let margin = Constants.Overlay.pointerMargin
+        return rectangle.insetBy(dx: -margin, dy: -margin).contains(point)
+    }
+
+    /// Registers the options popup so it keeps receiving clicks while it extends past the menu.
+    func setOptionsPopupRect(_ rect: NSRect?) {
+        optionsPopupRect = rect
+        updatePointerTransparency()
+    }
+
+    private func clearMenuHoverStates() {
+        overlayWindows.forEach { ($0.contentView as? OverlayView)?.clearHoverState() }
     }
     
     /// Refreshes overlays. If oldFrame and newFrame are provided, it invalidates only those regions.

--- a/ScrollSnap/Utilities/Constants.swift
+++ b/ScrollSnap/Utilities/Constants.swift
@@ -42,8 +42,17 @@ struct Constants {
     
     struct Overlay {
         static let backgroundColor: NSColor = NSColor.black.withAlphaComponent(0.5)
-        static let windowLevel: NSWindow.Level = .statusBar
+        /// Sits above every ordinary window but below the Dock and the menu bar, so both stay
+        /// visible and clickable while the overlay is up.
+        static let windowLevel: NSWindow.Level = NSWindow.Level(
+            rawValue: Int(CGWindowLevelForKey(.dockWindow)) - 1
+        )
         static let collectionBehavior: NSWindow.CollectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        /// Extra reach around the selection rectangle that still counts as overlay chrome,
+        /// matching the resize border zones in `SelectionRectangleView`.
+        static let pointerMargin: CGFloat = 20.0
+        /// Backstop for pointer movement the event monitors do not report.
+        static let pointerPollInterval: TimeInterval = 0.25
     }
     
     struct Thumbnail {

--- a/ScrollSnap/Views/MenuBarView.swift
+++ b/ScrollSnap/Views/MenuBarView.swift
@@ -380,6 +380,7 @@ class MenuBarView: NSView {
         if !isOptionsPopupVisible {
             hoveredOptionsPopupTarget = nil
         }
+        publishOptionsPopupRect()
         invalidateOverlay()
     }
 
@@ -387,7 +388,16 @@ class MenuBarView: NSView {
         guard isOptionsPopupVisible else { return }
         isOptionsPopupVisible = false
         hoveredOptionsPopupTarget = nil
+        publishOptionsPopupRect()
         invalidateOverlay()
+    }
+
+    /// Tells the manager how far the popup reaches so it keeps accepting clicks outside the menu bar.
+    private func publishOptionsPopupRect() {
+        guard let manager = manager else { return }
+        manager.setOptionsPopupRect(
+            isOptionsPopupVisible ? getOptionsPopupRect(for: manager.getMenuRectangle()) : nil
+        )
     }
 
     private func drawOptionsPopupIfNeeded(for menuRect: NSRect) {

--- a/ScrollSnap/Views/OverlayView.swift
+++ b/ScrollSnap/Views/OverlayView.swift
@@ -85,6 +85,11 @@ class OverlayView: NSView {
         updateTrackingAreas()
     }
     
+    /// Drops any hover feedback, used when the pointer leaves the overlay's own chrome.
+    func clearHoverState() {
+        menuBarView?.clearHoverState()
+    }
+    
     // MARK: - Drawing
     
     override func draw(_ dirtyRect: NSRect) {
@@ -169,15 +174,10 @@ class OverlayView: NSView {
             return
         }
         
-        guard let manager = manager else { return }
-        if let type = userInfo["type"] as? String {
-            if type == "menu" && manager.getIsScrollingCaptureActive() {
-                // Re-enable mouse events so the user can click the menu while scrolling capture is active
-                manager.setOverlayIgnoresMouseEvents(false)
-            }
-        } else if let zone = userInfo["zone"] as? String {
+        if let zone = userInfo["zone"] as? String {
             selectionRectangleView.handleMouseEnteredBorder(zone: zone)
-        } else {
+        } else if userInfo["type"] == nil {
+            // Menu and overlay hover feedback is driven by mouseMoved, not by entering.
             selectionRectangleView.handleMouseEntered()
         }
     }
@@ -189,10 +189,9 @@ class OverlayView: NSView {
             return
         }
         
-        guard let manager = manager else { return }
         if let type = userInfo["type"] as? String {
-            if type == "menu" && manager.getIsScrollingCaptureActive() {
-                manager.setOverlayIgnoresMouseEvents(true)
+            if type == "menu" {
+                menuBarView?.clearHoverState()
             }
         } else if userInfo["zone"] != nil {
             selectionRectangleView.handleMouseExitedBorder()


### PR DESCRIPTION
The overlay was a full-screen window at `.statusBar` level, which is above both the Dock and the menu bar, and it consumed every click on screen. Once it was up, Command-Tab was the only way to reach the app you wanted to capture.

Drops it to one level below the Dock so the Dock and menu bar stay visible and clickable, and only intercepts the pointer while it is over the overlay's own chrome: the selection rectangle plus its resize margin, the menu bar, and the options popup while open. Anywhere else the click passes through, so clicking a window under the dimmed area brings that app forward as usual.

Chrome tracking runs off local and global `NSEvent` mouse monitors, with a poll as a backstop for movement the monitors miss. The state is never flipped while a mouse button is held, so dragging or resizing past the edge of the selection keeps working.

The menu previously toggled click-through from `mouseEntered`/`mouseExited`, which cannot fire while the window ignores mouse events. Removed in favour of the above.

Also makes the global shortcut a capture toggle: show the overlay when idle, start the capture when it is up, finish a running one. The overlay is a non-activating panel, so Return and Escape only reach it while ScrollSnap has keyboard focus, which it does not have when you are lining up a capture in another app.
