### PR TITLE
Add a menu bar icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ ScrollSnap is an open-source macOS application designed to capture scrolling scr
 - **Interactive Menu**: Includes options to capture, save, reset positions, or cancel, with a draggable interface.
 - **Thumbnail Preview**: Displays a draggable thumbnail of the captured image with swipe-to-save or right-click options.
 - **Save Destinations**: Supports saving to Desktop, Documents, Downloads, Clipboard, or opening in Preview.
+- **Menu Bar Icon**: Capture, open Settings, or quit from the menu bar — ScrollSnap has no Dock icon, so this is its standing interface. It can be hidden in Settings.
 - **Settings**: Adjust language and reset selection and menu positions via the native settings window (Command + ,).
 
 ## 🌍 Multi-Language Support
@@ -86,7 +87,7 @@ Whether you want to add a completely new language or improve an existing transla
 
 9. **Quit**:
 
-- Press `Cmd + Q` or select "Quit ScrollSnap" from the Options menu.
+- Choose "Quit ScrollSnap" from the menu bar icon, press `Cmd + Q`, or select "Quit ScrollSnap" from the overlay's Options menu.
 
 ## Project Structure
 
@@ -107,6 +108,7 @@ ScrollSnap
 │   │── ThumbnailView.swift        # Thumbnail preview UI
 │── Managers
 │   │── OverlayManager.swift       # Overlay and state management
+│   │── StatusItemController.swift # Menu bar icon and its menu
 │   │── StitchingManager.swift     # Image stitching for scrolling capture
 ```
 

--- a/ScrollSnap.xcodeproj/project.pbxproj
+++ b/ScrollSnap.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D4A100012F20000100AA0001 /* ScrollingCaptureSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A100022F20000100AA0001 /* ScrollingCaptureSession.swift */; };
+		D4A300052F30000100AA0001 /* StatusItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A300062F30000100AA0001 /* StatusItemController.swift */; };
 		D4A200012F20000100AA0001 /* ScrollingCaptureSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A200032F20000100AA0001 /* ScrollingCaptureSessionTests.swift */; };
 		D4A200022F20000100AA0001 /* StitchingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A200042F20000100AA0001 /* StitchingManagerTests.swift */; };
 		E10000012F10000100AA0001 /* GlobalShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10000112F10000100AA0001 /* GlobalShortcut.swift */; };
@@ -72,6 +73,7 @@
 
 /* Begin PBXFileReference section */
 		D4A100022F20000100AA0001 /* ScrollingCaptureSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingCaptureSession.swift; sourceTree = "<group>"; };
+		D4A300062F30000100AA0001 /* StatusItemController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusItemController.swift; sourceTree = "<group>"; };
 		D4A200032F20000100AA0001 /* ScrollingCaptureSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollingCaptureSessionTests.swift; sourceTree = "<group>"; };
 		D4A200042F20000100AA0001 /* StitchingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchingManagerTests.swift; sourceTree = "<group>"; };
 		D4A200052F20000100AA0001 /* ScrollSnapTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScrollSnapTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -167,6 +169,7 @@
 			children = (
 				D4BBCA6C2D5A11370022FF73 /* OverlayManager.swift */,
 				D4A100022F20000100AA0001 /* ScrollingCaptureSession.swift */,
+				D4A300062F30000100AA0001 /* StatusItemController.swift */,
 				D4BBCA872D7276D20022FF73 /* StitchingManager.swift */,
 				E10000122F10000100AA0001 /* LoginItemManager.swift */,
 			);
@@ -420,6 +423,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4A100012F20000100AA0001 /* ScrollingCaptureSession.swift in Sources */,
+				D4A300052F30000100AA0001 /* StatusItemController.swift in Sources */,
 				E10000012F10000100AA0001 /* GlobalShortcut.swift in Sources */,
 				E10000022F10000100AA0001 /* LoginItemManager.swift in Sources */,
 				D40200052F00000100AA0001 /* LocalizationSupport.swift in Sources */,

--- a/ScrollSnap/App/AppDelegate.swift
+++ b/ScrollSnap/App/AppDelegate.swift
@@ -11,6 +11,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     let overlayManager = OverlayManager()
     let loginItemManager = LoginItemManager()
     private let updateFeedbackManager = UpdateFeedbackManager()
+    private let statusItemController = StatusItemController()
+    private var menuBarIconObservation: NSKeyValueObservation?
     private var localKeyEventMonitor: Any?
     private var shortcutTask: Task<Void, Never>?
     private var screenRecordingPermissionWindow: NSWindow?
@@ -25,6 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         installGlobalShortcutHandler()
         overlayManager.openSettings = { [weak self] in self?.openSettings() }
         overlayManager.quit = { [weak self] in self?.quit() }
+        installStatusItem()
 
         isLoginLaunch = isLoginLaunch
             || ProcessInfo.processInfo.arguments.contains("--launch-at-login")
@@ -52,6 +55,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
         shortcutTask?.cancel()
         shortcutTask = nil
+        menuBarIconObservation?.invalidate()
+        menuBarIconObservation = nil
+    }
+
+    // MARK: - Menu Bar Icon
+
+    /// ScrollSnap has no Dock icon, so the menu bar item is its only standing interface.
+    private func installStatusItem() {
+        statusItemController.capture = { [weak self] in self?.presentCaptureInterface() }
+        statusItemController.openSettings = { [weak self] in self?.openSettings() }
+        statusItemController.quit = { [weak self] in self?.quit() }
+        statusItemController.syncWithPreference()
+
+        // Observing the single key rather than `UserDefaults.didChangeNotification`, which fires for
+        // every write the app makes, including the selection frame saved on each drag step.
+        menuBarIconObservation = UserDefaults.standard.observe(
+            \.ShowMenuBarIcon,
+            options: [.new]
+        ) { [weak self] _, _ in
+            Task { @MainActor in
+                self?.statusItemController.syncWithPreference()
+            }
+        }
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/ScrollSnap/Localizable.xcstrings
+++ b/ScrollSnap/Localizable.xcstrings
@@ -3487,6 +3487,30 @@
           }
         }
       }
+    },
+    "Show icon in the menu bar" : {
+      "comment" : "Settings toggle for the ScrollSnap menu bar icon.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show icon in the menu bar"
+          }
+        }
+      }
+    },
+    "Without the icon, use the global shortcut to show ScrollSnap." : {
+      "comment" : "Settings hint shown when the menu bar icon is turned off.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Without the icon, use the global shortcut to show ScrollSnap."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/ScrollSnap/Managers/StatusItemController.swift
+++ b/ScrollSnap/Managers/StatusItemController.swift
@@ -1,0 +1,107 @@
+//
+//  StatusItemController.swift
+//  ScrollSnap
+//
+
+import AppKit
+
+/// Whether ScrollSnap shows its menu bar icon.
+enum MenuBarIconSettings {
+    static func isVisible(userDefaults: UserDefaults = .standard) -> Bool {
+        userDefaults.object(forKey: Constants.MenuBarIcon.visibleKey) as? Bool ?? true
+    }
+}
+
+extension UserDefaults {
+    /// Key-value observing shim for `Constants.MenuBarIcon.visibleKey`. The property name has to
+    /// match the defaults key exactly for `observe(\.ShowMenuBarIcon)` to receive changes.
+    @objc dynamic var ShowMenuBarIcon: Bool {
+        bool(forKey: Constants.MenuBarIcon.visibleKey)
+    }
+}
+
+/// Owns the menu bar icon, which is the app's only persistent interface: ScrollSnap runs as an
+/// agent (`LSUIElement`), so without it there is no way to capture, open settings, or quit unless
+/// the overlay happens to be on screen.
+@MainActor
+final class StatusItemController: NSObject {
+    var capture: () -> Void = {}
+    var openSettings: () -> Void = {}
+    var quit: () -> Void = {}
+
+    private var statusItem: NSStatusItem?
+
+    var isVisible: Bool {
+        statusItem != nil
+    }
+
+    /// Adds or removes the icon to match the stored preference.
+    func syncWithPreference() {
+        if MenuBarIconSettings.isVisible() {
+            show()
+        } else {
+            hide()
+        }
+    }
+
+    func show() {
+        guard statusItem == nil else { return }
+
+        let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let appName = Self.appName
+
+        if let button = statusItem.button {
+            let icon = NSImage(systemSymbolName: "rectangle.dashed", accessibilityDescription: appName)
+            icon?.isTemplate = true // Follows the menu bar's light and dark appearance.
+            button.image = icon
+            button.toolTip = appName
+        }
+
+        statusItem.menu = makeMenu()
+        self.statusItem = statusItem
+    }
+
+    func hide() {
+        guard let statusItem else { return }
+        NSStatusBar.system.removeStatusItem(statusItem)
+        self.statusItem = nil
+    }
+
+    // MARK: - Menu
+
+    private func makeMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.addItem(makeItem(title: AppText.capture, action: #selector(handleCapture)))
+        menu.addItem(.separator())
+        // No key equivalent for capture: the recorder in Settings refuses shortcuts already taken by
+        // a menu item, and that would make the current global shortcut unselectable.
+        menu.addItem(makeItem(title: AppText.settings, action: #selector(handleOpenSettings), keyEquivalent: ","))
+        menu.addItem(.separator())
+        menu.addItem(makeItem(title: AppText.quitApp, action: #selector(handleQuit), keyEquivalent: "q"))
+        return menu
+    }
+
+    private func makeItem(title: String, action: Selector, keyEquivalent: String = "") -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
+        item.target = self
+        return item
+    }
+
+    @objc private func handleCapture() {
+        capture()
+    }
+
+    @objc private func handleOpenSettings() {
+        openSettings()
+    }
+
+    @objc private func handleQuit() {
+        quit()
+    }
+
+    private static var appName: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
+            ?? "ScrollSnap"
+    }
+}

--- a/ScrollSnap/Utilities/Constants.swift
+++ b/ScrollSnap/Utilities/Constants.swift
@@ -46,6 +46,10 @@ struct Constants {
         static let collectionBehavior: NSWindow.CollectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     }
     
+    struct MenuBarIcon {
+        static let visibleKey = "ShowMenuBarIcon"
+    }
+    
     struct Thumbnail {
         static let clickDistanceThreshold: CGFloat = 5    // Max movement for a click
         static let swipeDistanceThreshold: CGFloat = 20   // Min distance for swipe-right save

--- a/ScrollSnap/Utilities/LocalizationSupport.swift
+++ b/ScrollSnap/Utilities/LocalizationSupport.swift
@@ -221,6 +221,14 @@ enum AppText {
         text("This shortcut is already used by macOS.")
     }
 
+    static var showMenuBarIcon: String {
+        text("Show icon in the menu bar")
+    }
+
+    static var menuBarIconHiddenHint: String {
+        text("Without the icon, use the global shortcut to show ScrollSnap.")
+    }
+
     static var launchAtLogin: String {
         text("Launch at Login")
     }

--- a/ScrollSnap/Views/SettingsView.swift
+++ b/ScrollSnap/Views/SettingsView.swift
@@ -18,6 +18,9 @@ struct SettingsView: View {
     @AppStorage(AppLanguage.storageKey)
     private var selectedLanguageRawValue = AppLanguage.defaultValue.rawValue
     
+    @AppStorage(Constants.MenuBarIcon.visibleKey)
+    private var showsMenuBarIcon = true
+
     @State private var initialLanguageRawValue: String = ""
     @State private var shortcutFeedback: String?
 
@@ -129,6 +132,14 @@ struct SettingsView: View {
             }
 
             Section {
+                Toggle(AppText.showMenuBarIcon, isOn: $showsMenuBarIcon)
+
+                if !showsMenuBarIcon {
+                    Text(AppText.menuBarIconHiddenHint)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
                 Toggle(
                     AppText.launchAtLogin,
                     isOn: Binding(


### PR DESCRIPTION
The app runs as an agent (`LSUIElement`), so it has no Dock icon and no app menu. With the overlay dismissed there is no way to capture, reach Settings or quit it, short of Activity Monitor.

Adds a status item with Capture, Settings and Quit. Capture goes through the same entry point as the global shortcut. The icon is a template image so it follows the menu bar appearance, and it can be turned off in Settings.

The preference is watched with KVO on that one key rather than `UserDefaults.didChangeNotification`, which fires for every write the app makes, including the selection frame saved on each step of a drag.

The capture item deliberately has no key equivalent: the shortcut recorder in Settings rejects shortcuts already claimed by a menu item, which would make the current global shortcut unselectable.

Two new strings, English only.
